### PR TITLE
New function ush_printf() providing a more flexible command output to console

### DIFF
--- a/examples/demo_linux/fs/path/bin.c
+++ b/examples/demo_linux/fs/path/bin.c
@@ -52,11 +52,7 @@ static void uptime_exec_callback(struct ush_object *self, struct ush_file_descri
                 return;
         }
 
-        time_t uptime = time(NULL) - start_time;
-        snprintf(self->desc->output_buffer, self->desc->output_buffer_size, "time: %lus\r\n", uptime);
-        self->desc->output_buffer[self->desc->output_buffer_size - 1] = 0;
-
-        ush_flush(self);
+        ush_printf(self, "time: %lus\r\n", time(NULL) - start_time);
 }
 
 static const struct ush_file_descriptor g_bin_desc[] = {

--- a/src/inc/ush.h
+++ b/src/inc/ush.h
@@ -119,6 +119,16 @@ void ush_print_no_newline(struct ush_object *self, char *buf);
 void ush_print(struct ush_object *self, char *buf);
 
 /**
+ * @brief Print formatted custom message.
+ *
+ * Function to print formatted custom message to output shell interface.
+ *
+ * @param self - pointer to master ush object
+ * @param format - pointer to printf format string
+ */
+void ush_printf(struct ush_object *self, const char *format, ...);
+
+/**
  * @brief Flush output buffer.
  * 
  * Function to print output buffer content to shell output interface.

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -116,21 +116,21 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         USH_ASSERT(self != NULL);
         USH_ASSERT(format != NULL);
 
-        // Make sure that the default output_buffer always is used
+        /* Make sure that the default output_buffer always is used */
         if (self->write_buf != self->desc->output_buffer)
         {
-                // Reset output_buffer to start position
+                /* Reset output_buffer to start position */
                 self->desc->output_buffer[0] = '\0';
                 ush_write_pointer(self, self->desc->output_buffer, USH_STATE_RESET_PROMPT);
         }
         else
         {
-                // Allow concatenation to output_buffer
+                /* Allow concatenation to output_buffer */
                 self->state = USH_STATE_WRITE_CHAR;
                 self->write_next_state = USH_STATE_RESET_PROMPT;
         }
 
-        // Concatenate string to the output_buffer pointed to by self->write_buf
+        /* Concatenate string to the output_buffer pointed to by self->write_buf */
         va_list arg_list;
         va_start(arg_list, format);
         size_t insert_idx = strlen(self->write_buf);
@@ -139,9 +139,9 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         int written_size_real = strlen(&self->write_buf[insert_idx]);
         self->write_size += written_size_real;
 
-        // Handle possible vsnprintf() problems
-        if (written_size_ideal < 0 ||                   // Format error
-            written_size_ideal > written_size_real)     // Available output_buffer to small
+        /* Handle possible vsnprintf() problems */
+        if (written_size_ideal < 0 ||                   /* Format error */
+            written_size_ideal > written_size_real)     /* Available output_buffer to small */
         {
                 int error_msg_size;
                 const char *error_msg;
@@ -159,17 +159,17 @@ void ush_printf(struct ush_object *self, const char *format, ...)
                         error_msg_size = sizeof(error_overflow);
                 }
 
-                // Do the error message fit into output_buffer pointed to by self->write_buf?
+                /* Do the error message fit into output_buffer pointed to by self->write_buf? */
                 if (self->desc->output_buffer_size - strlen(self->write_buf) >= strlen(error_msg))
                 {
-                        // Error message fits
+                        /* Error message fits */
                         size_t end_idx = strlen(self->write_buf);
                         (void)snprintf(&self->write_buf[end_idx], error_msg_size, "%s", error_msg);
                         self->write_size += strlen(&self->write_buf[end_idx]);
                 }
                 else
                 {
-                        // Error message does NOT fit
+                        /* Error message does NOT fit */
                         size_t end_idx = self->desc->output_buffer_size - error_msg_size;
                         (void)snprintf(&self->write_buf[end_idx], error_msg_size, "%s", error_msg);
                         self->write_size = self->desc->output_buffer_size;

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -119,10 +119,15 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         // Make sure that the the default output_buffer always is used
         if (self->write_buf != self->desc->output_buffer)
         {
-                self->write_pos = 0;
-                self->write_size = 0;
-                self->write_buf = self->desc->output_buffer;
-                self->write_buf[0] = '\0';                 
+                // Reset to output_buffer to start position
+                self->desc->output_buffer[0] = '\0';
+                ush_write_pointer(self, self->desc->output_buffer, USH_STATE_RESET_PROMPT);
+        }
+        else
+        {
+                // Allow concatenation to output_buffer  
+                self->state = USH_STATE_WRITE_CHAR;
+                self->write_next_state = USH_STATE_RESET_PROMPT;
         }
 
         // An va_list can only be used by ONE vsnprintf() call with some toolchains  
@@ -159,9 +164,6 @@ void ush_printf(struct ush_object *self, const char *format, ...)
                 (void)snprintf(&self->write_buf[end_pos], sizeof(error_str), "%s", error_str);
                 self->write_size += strlen(&self->write_buf[end_pos]);
         }
-
-        self->state = USH_STATE_WRITE_CHAR;
-        self->write_next_state = USH_STATE_RESET_PROMPT;
 
         va_end(arg_copy);
         va_end(arg_original);

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -75,9 +75,9 @@ bool ush_service(struct ush_object *self)
         bool busy = false;
 
         if (ush_reset_service(self) != false)
-                return true;
+                return true;        
         if (ush_prompt_service(self) != false)
-                return true;
+                return true;        
         if (ush_read_service(self, &busy) != false)
                 return busy;
 #if USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE == 1
@@ -85,7 +85,7 @@ bool ush_service(struct ush_object *self)
                 return true;
 #endif /* USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE */
         if (ush_parse_service(self) != false)
-                return true;
+                return true;        
         if (ush_write_service(self) != false)
                 return true;
         if (ush_process_service(self) != false)

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -146,22 +146,27 @@ void ush_printf(struct ush_object *self, const char *format, ...)
                 (void)vsnprintf(&self->write_buf[insert_pos], max_cat_size + 1, format, arg_copy);
                 self->write_size += strlen(&self->write_buf[insert_pos]);
         }
-        else if (num_char < 0)
-        {
-                // Format string error
-                const char error_str[] = "...format error\r\n";
-                size_t end_pos = max_cat_size >= strlen(error_str) ? insert_pos :
-                                 self->desc->output_buffer_size - sizeof(error_str);
-                (void)snprintf(&self->write_buf[end_pos], sizeof(error_str), "%s", error_str);
-                self->write_size += strlen(&self->write_buf[end_pos]);
-        }
         else
         {
-                // Format string larger than available buffer
-                const char error_str[] = "...overflow error\r\n";
-                size_t end_pos = max_cat_size >= strlen(error_str) ? insert_pos :
-                                 self->desc->output_buffer_size - sizeof(error_str);
-                (void)snprintf(&self->write_buf[end_pos], sizeof(error_str), "%s", error_str);
+                int error_msg_size;
+                const char *error_msg;
+                const char error_format[] = "...format error\r\n";
+                const char error_overflow[] = "...overflow error\r\n";
+
+                if (num_char < 0)
+                {
+                        error_msg = error_format;
+                        error_msg_size = sizeof(error_format);
+                }
+                else
+                {
+                        error_msg = error_overflow;
+                        error_msg_size = sizeof(error_overflow);
+                }  
+
+                size_t end_pos = max_cat_size >= strlen(error_msg) ? insert_pos :
+                                 self->desc->output_buffer_size - error_msg_size;
+                (void)snprintf(&self->write_buf[end_pos], error_msg_size, "%s", error_msg);
                 self->write_size += strlen(&self->write_buf[end_pos]);
         }
 

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -117,14 +117,11 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         USH_ASSERT(format != NULL);
 
         /* Make sure that the default output_buffer always is used */
-        if (self->write_buf != self->desc->output_buffer)
-        {
+        if (self->write_buf != self->desc->output_buffer) {
                 /* Reset output_buffer to start position */
                 self->desc->output_buffer[0] = '\0';
                 ush_write_pointer(self, self->desc->output_buffer, USH_STATE_RESET_PROMPT);
-        }
-        else
-        {
+        } else {
                 /* Allow concatenation to output_buffer */
                 self->state = USH_STATE_WRITE_CHAR;
                 self->write_next_state = USH_STATE_RESET_PROMPT;
@@ -140,35 +137,29 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         self->write_size += written_size_real;
 
         /* Handle possible vsnprintf() problems */
-        if (written_size_ideal < 0 ||                   /* Format error */
-            written_size_ideal > written_size_real)     /* Available output_buffer to small */
+        if (written_size_ideal < 0 || /* Format error */
+            written_size_ideal > written_size_real) /* Available output_buffer to small */
         {
                 int error_msg_size;
                 const char *error_msg;
                 const char error_format[] = "...format error\r\n";
                 const char error_overflow[] = "...overflow error\r\n";
 
-                if (written_size_ideal < 0)
-                {
+                if (written_size_ideal < 0) {
                         error_msg = error_format;
                         error_msg_size = sizeof(error_format);
-                }
-                else
-                {
+                } else {
                         error_msg = error_overflow;
                         error_msg_size = sizeof(error_overflow);
                 }
 
                 /* Do the error message fit into output_buffer pointed to by self->write_buf? */
-                if (self->desc->output_buffer_size - strlen(self->write_buf) >= strlen(error_msg))
-                {
+                if (self->desc->output_buffer_size - strlen(self->write_buf) >= strlen(error_msg)) {
                         /* Error message fits */
                         size_t end_idx = strlen(self->write_buf);
                         (void)snprintf(&self->write_buf[end_idx], error_msg_size, "%s", error_msg);
                         self->write_size += strlen(&self->write_buf[end_idx]);
-                }
-                else
-                {
+                } else {
                         /* Error message does NOT fit */
                         size_t end_idx = self->desc->output_buffer_size - error_msg_size;
                         (void)snprintf(&self->write_buf[end_idx], error_msg_size, "%s", error_msg);

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -116,10 +116,6 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         USH_ASSERT(self != NULL);
         USH_ASSERT(format != NULL);
 
-        // An va_list can only be used by ONE vsnprintf() call with some toolchains
-        va_list arg_list;
-        va_start(arg_list, format);
-
         // Make sure that the default output_buffer always is used
         if (self->write_buf != self->desc->output_buffer)
         {
@@ -135,6 +131,8 @@ void ush_printf(struct ush_object *self, const char *format, ...)
         }
 
         // Concatenate string to the output_buffer pointed to by self->write_buf
+        va_list arg_list;
+        va_start(arg_list, format);
         size_t insert_idx = strlen(self->write_buf);
         size_t write_size_max = self->desc->output_buffer_size - insert_idx;
         int written_size_ideal = vsnprintf(&self->write_buf[insert_idx], write_size_max, format, arg_list);
@@ -143,7 +141,7 @@ void ush_printf(struct ush_object *self, const char *format, ...)
 
         // Handle possible vsnprintf() problems
         if (written_size_ideal < 0 ||                   // Format error
-            written_size_ideal > written_size_real)     // Buffer size to small
+            written_size_ideal > written_size_real)     // Available output_buffer to small
         {
                 int error_msg_size;
                 const char *error_msg;

--- a/tests/func_tests/test_func.c
+++ b/tests/func_tests/test_func.c
@@ -249,15 +249,12 @@ void test_func_write(const char *text)
 
 void test_func_read(bool reset_g_write_buf_index, int ush_service_loops)
 {
-        if (reset_g_write_buf_index)
-        {
+        if (reset_g_write_buf_index) {
                 g_write_buf_index = 0;
         }
 
-        for (int i = 0; i < ush_service_loops; i++)
-        {
-                if (!ush_service(&g_ush))
-                {
+        for (int i = 0; i < ush_service_loops; i++) {
+                if (!ush_service(&g_ush)) {
                         break;
                 }
         }

--- a/tests/func_tests/test_func.c
+++ b/tests/func_tests/test_func.c
@@ -247,6 +247,23 @@ void test_func_write(const char *text)
         strcpy(g_read_buf, text);
 }
 
+void test_func_read(bool reset_g_write_buf_index, int ush_service_loops)
+{
+        if (reset_g_write_buf_index)
+        {
+                g_write_buf_index = 0;
+        }
+
+        for (int i = 0; i < ush_service_loops; i++)
+        {
+                if (!ush_service(&g_ush))
+                {
+                        break;
+                }
+        }
+        g_write_buf[g_write_buf_index] = '\0';
+}
+
 void test_func_read_all(void)
 {
         g_write_buf_index = 0;

--- a/tests/func_tests/test_func.h
+++ b/tests/func_tests/test_func.h
@@ -59,6 +59,7 @@ extern struct ush_node_object g_path_dir111;
 void test_func_init(void);
 void test_func_deinit(void);
 void test_func_write(const char *text);
+void test_func_read(bool reset_g_write_buf_index, int ush_service_loops);
 void test_func_read_all(void);
 
 #define TEST_FUNC_ASK(request, response) \

--- a/tests/func_tests/test_func_print.c
+++ b/tests/func_tests/test_func_print.c
@@ -57,7 +57,7 @@ void test_print(void)
 void test_printf(void)
 {
         // Test with formatting options and concatenation when test_string has been
-        // partially been read by fist test_func_read()
+        // partially read by first test_func_read()
         char test_string[] = "line%s%d\r\n";
         ush_printf(&g_ush, test_string, "string", 0);
         test_func_read(true, strlen(test_string) / 2);

--- a/tests/func_tests/test_func_print.c
+++ b/tests/func_tests/test_func_print.c
@@ -68,7 +68,7 @@ void test_printf(void)
                                  "[test /]$ ", g_write_buf);
 }
 
-void tetest_printf_long(void)
+void test_printf_long(void)
 {
         // Test with longest possible string
         char test_string[TEST_FUNC_WORK_BUFFER_SIZE];
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 
         RUN_TEST(test_print);
         RUN_TEST(test_printf);
-        RUN_TEST(tetest_printf_long);
+        RUN_TEST(test_printf_long);
         RUN_TEST(test_printf_format_error);
         RUN_TEST(test_printf_overflow_error);
         RUN_TEST(test_print_status);

--- a/tests/func_tests/test_func_print.c
+++ b/tests/func_tests/test_func_print.c
@@ -63,9 +63,10 @@ void test_printf(void)
         test_func_read(true, strlen(test_string) / 2);
         ush_printf(&g_ush, test_string, "string", 1);
         test_func_read(false, INT_MAX);
-        TEST_ASSERT_EQUAL_STRING("linestring0\r\n" \
-                                 "linestring1\r\n" \
-                                 "[test /]$ ", g_write_buf);
+        TEST_ASSERT_EQUAL_STRING("linestring0\r\n"
+                                 "linestring1\r\n"
+                                 "[test /]$ ",
+                                 g_write_buf);
 }
 
 void test_printf_long(void)
@@ -85,8 +86,9 @@ void test_printf_format_error(void)
         ush_printf(&g_ush, "string0");
         ush_printf(&g_ush, "%lc", 0xffffffff);
         test_func_read_all();
-        TEST_ASSERT_EQUAL_STRING("string0...format error\r\n" \
-                                 "[test /]$ ", g_write_buf);
+        TEST_ASSERT_EQUAL_STRING("string0...format error\r\n"
+                                 "[test /]$ ",
+                                 g_write_buf);
 }
 
 void test_printf_overflow_error(void)

--- a/tests/func_tests/test_func_print.c
+++ b/tests/func_tests/test_func_print.c
@@ -56,8 +56,8 @@ void test_print(void)
 
 void test_printf(void)
 {
-        // Test with formatting options and concatenation when test_string has been
-        // partially read by first test_func_read()
+        /* Test with formatting options and concatenation when test_string has been
+           partially read by first test_func_read() */
         char test_string[] = "line%s%d\r\n";
         ush_printf(&g_ush, test_string, "string", 0);
         test_func_read(true, strlen(test_string) / 2);
@@ -70,7 +70,7 @@ void test_printf(void)
 
 void test_printf_long(void)
 {
-        // Test with longest possible string
+        /* Test with longest possible string */
         char test_string[TEST_FUNC_WORK_BUFFER_SIZE];
         size_t test_string_len = fill_string(test_string, sizeof(test_string));
         ush_printf(&g_ush, "%s", test_string);
@@ -81,7 +81,7 @@ void test_printf_long(void)
 
 void test_printf_format_error(void)
 {
-        // Test simple string and and then concatentate invalid formatting options
+        /* Test simple string and and then concatentate invalid formatting options */
         ush_printf(&g_ush, "string0");
         ush_printf(&g_ush, "%lc", 0xffffffff);
         test_func_read_all();
@@ -91,7 +91,7 @@ void test_printf_format_error(void)
 
 void test_printf_overflow_error(void)
 {
-        // Test with two simple strings and then concatenate overflow_string
+        /* Test with two simple strings and then concatenate overflow_string */
         const char first_string[] = "string0";
         char test_string[TEST_FUNC_WORK_BUFFER_SIZE - strlen(first_string)];
         (void)fill_string(test_string, sizeof(test_string));

--- a/tests/func_tests/test_func_print.c
+++ b/tests/func_tests/test_func_print.c
@@ -56,15 +56,20 @@ void test_print(void)
 
 void test_printf(void)
 {
-        // Test with formatting options and concatenation
-        ush_printf(&g_ush, "line%s%d\r\n", "string", 0);
-        test_func_read(true, 4);
-        ush_printf(&g_ush, "line%s%d\r\n", "string", 1);
+        // Test with formatting options and concatenation when test_string has been
+        // partially been read by fist test_func_read()
+        char test_string[] = "line%s%d\r\n";
+        ush_printf(&g_ush, test_string, "string", 0);
+        test_func_read(true, strlen(test_string) / 2);
+        ush_printf(&g_ush, test_string, "string", 1);
         test_func_read(false, INT_MAX);
         TEST_ASSERT_EQUAL_STRING("linestring0\r\n" \
                                  "linestring1\r\n" \
                                  "[test /]$ ", g_write_buf);
+}
 
+void tetest_printf_long(void)
+{
         // Test with longest possible string
         char test_string[TEST_FUNC_WORK_BUFFER_SIZE];
         size_t test_string_len = fill_string(test_string, sizeof(test_string));
@@ -143,6 +148,7 @@ int main(int argc, char *argv[])
 
         RUN_TEST(test_print);
         RUN_TEST(test_printf);
+        RUN_TEST(tetest_printf_long);
         RUN_TEST(test_printf_format_error);
         RUN_TEST(test_printf_overflow_error);
         RUN_TEST(test_print_status);


### PR DESCRIPTION
Implemented new function ush_printf() to get better flexibility of command output to console.
It is possible to use multiple calls as ush_printf() output is by default concatenated in the output_buffer.
