### PR TITLE
Removed unneeded cast to unsigned int from unsigned long int (size_t) …

### DIFF
--- a/src/src/commands/ush_cmd_xxd.c
+++ b/src/src/commands/ush_cmd_xxd.c
@@ -77,7 +77,7 @@ bool ush_buildin_cmd_xxd_service(struct ush_object *self, struct ush_file_descri
         case USH_STATE_PROCESS_SERVICE: {
                 switch (self->process_index) {
                 case 0:
-                        sprintf(self->desc->output_buffer, "%08X: ", (uint32_t)self->process_index_item);
+                        sprintf(self->desc->output_buffer, "%08lX: ", self->process_index_item);
                         ush_write_pointer(self, self->desc->output_buffer, self->state);
                         self->process_index = 1;
                         break;


### PR DESCRIPTION
closes #13 

Brief: using lX specifier instead in place of X specifier allows passing of size_t as it is an unsigned long.