### PR TITLE
Remove compile errors when using GCC 13.2.0 in Ubuntu 24.04 LTS

### DIFF
--- a/tests/unit_tests/test_unit_autocomp_utils.c
+++ b/tests/unit_tests/test_unit_autocomp_utils.c
@@ -631,7 +631,6 @@ void test_ush_autocomp_process_file_index(void)
         for (int i = 0; i < 10; i++) {
                 setUp();
                 ush.process_index = i;
-                ush.process_node = &node;
 
                 switch (i) {
                 case 0:

--- a/tests/unit_tests/test_unit_cmd_cat.c
+++ b/tests/unit_tests/test_unit_cmd_cat.c
@@ -262,7 +262,7 @@ void test_ush_buildin_cmd_cat_callback_pos(void)
         char *argv[4] = {0};
         struct ush_file_descriptor file0;
         struct ush_file_descriptor file1;
-        struct ush_file_descriptor cat_cmd;
+        struct ush_file_descriptor cat_cmd = {0};
 
         argv[1] = "test";
         argv[2] = "test2";
@@ -325,7 +325,7 @@ void test_ush_buildin_cmd_cat_service_states(void)
 
 void test_ush_buildin_cmd_cat_service_process(void)
 {
-        struct ush_file_descriptor cat_cmd;
+        struct ush_file_descriptor cat_cmd = {0};
         struct ush_file_descriptor file0;
         struct ush_file_descriptor file1;
 

--- a/tests/unit_tests/test_unit_cmd_help.c
+++ b/tests/unit_tests/test_unit_cmd_help.c
@@ -258,7 +258,7 @@ void test_ush_buildin_cmd_help_service_states(void)
 
 void test_ush_buildin_cmd_help_service_end(void)
 {
-        struct ush_file_descriptor cmd_file;
+        struct ush_file_descriptor cmd_file = {0};
         bool ret;
 
         ush.state = USH_STATE_PROCESS_START;
@@ -279,7 +279,7 @@ void test_ush_buildin_cmd_help_service_end(void)
 
 void test_ush_buildin_cmd_help_service_next(void)
 {
-        struct ush_file_descriptor cmd_file;
+        struct ush_file_descriptor cmd_file = {0};
         struct ush_node_object node = {0};
         bool ret;
 

--- a/tests/unit_tests/test_unit_commands.c
+++ b/tests/unit_tests/test_unit_commands.c
@@ -63,7 +63,7 @@ void test_ush_commands_add(void)
 
 void test_ush_commands_add_multi(void)
 {
-        struct ush_file_descriptor files;
+        struct ush_file_descriptor files = {0};
 
         struct ush_node_object cmd1 = {0};
         struct ush_node_object cmd2 = {0};


### PR DESCRIPTION
Removes the following warnings/errors:

error: <variable> may be used uninitialized
error: storing the address of local variable ‘node’ in ‘ush.process_node’
